### PR TITLE
Add visible coordinate marker to OSM map

### DIFF
--- a/src/checkWikidata.js
+++ b/src/checkWikidata.js
@@ -33,7 +33,7 @@ module.exports = function checkWikidata (id, dom, callback) {
       if (el.claims.P625) {
         const coords = el.claims.P625[0].mainsnak.datavalue.value
 
-        ul.innerHTML += '<li class="success">Eintrag hat Koordinaten: <a target="_blank" href="https://openstreetmap.org/#map=19/' + coords.latitude + '/' + coords.longitude + '">' + coords.latitude + ', ' + coords.longitude + '</a></li>'
+        ul.innerHTML += '<li class="success">Eintrag hat Koordinaten: <a target="_blank" href="https://openstreetmap.org/?mlat=' + coords.latitude + '&mlon=' + coords.longitude + '#map=19/' + coords.latitude + '/' + coords.longitude + '">' + coords.latitude + ', ' + coords.longitude + '</a></li>'
       } else {
         ul.innerHTML += '<li class="warning">Eintrag hat keine Koordinaten</li>'
       }


### PR DESCRIPTION
I'm not sure about the accuracy of the coordinates provided, but I think (especially for point-like objects) these markers help spot the actual place on the map.
I stumbled upon this when I was watching the entry of a large cross which was at a cemetery, but there were two cemeteries on the map behind the link. A marker would have helped in that case.